### PR TITLE
Ability to set start/end date - Surface totalResults in report response

### DIFF
--- a/lib/garb/model.rb
+++ b/lib/garb/model.rb
@@ -26,7 +26,7 @@ module Garb
     end
 
     def results(profile, options = {})
-      default_params = build_default_params(profile)
+      default_params = build_default_params(profile, options)
 
       param_set = [
         default_params,
@@ -70,11 +70,11 @@ module Garb
       sort
     end
 
-    def build_default_params(profile)
+    def build_default_params(profile, options)
       {
         'ids' => Garb.to_ga(profile.id),
-        'start-date' => format_time(Time.now - Model::MONTH),
-        'end-date' => format_time(Time.now)
+        'start-date' => format_time(options['start_date'] || Time.now - Model::MONTH),
+        'end-date' => format_time(options['end_date'] || Time.now)
       }
     end
 

--- a/lib/garb/report_response.rb
+++ b/lib/garb/report_response.rb
@@ -11,6 +11,11 @@ module Garb
       @results ||= parse
     end
 
+    def total_results
+      response_hash = Crack::XML.parse(@xml)
+      response_hash ? response_hash['feed']['openSearch:totalResults'].to_i : 0
+    end
+
     private
     def parse
       entries.map do |entry|

--- a/test/fixtures/report_feed.xml
+++ b/test/fixtures/report_feed.xml
@@ -14,10 +14,10 @@
     </author>    
   <openSearch:startIndex>3</openSearch:startIndex>
   <openSearch:itemsPerPage>4</openSearch:itemsPerPage>
+  <openSearch:totalResults>6</openSearch:totalResults>
   <ga:webPropertyID>UA-983247-67</ga:webPropertyID>
   <ga:start-date>2008-01-01</ga:start-date>
   <ga:end-date>2008-01-02</ga:end-date>
-
   <entry>
     <id> http://www.google.com/analytics/feeds/data?ids=ga:1174&amp;ga:country=%28not%20set%29&amp;ga:city=%28not%20set%29&amp;start-date=2008-01-01&amp;end-date=2008-01-02 </id>
     <updated> 2008-01-01T16:00:00.001-08:00 </updated>

--- a/test/unit/garb/model_test.rb
+++ b/test/unit/garb/model_test.rb
@@ -116,6 +116,15 @@ module Garb
           end
 
           # should "be able to shift the date range"
+          should "be able to set start date" do
+            assert_equal ['result'], @test_model.results(@profile, 'start_date' => (Date.today - 7))
+            assert_data_params(@params.merge({'start-date' => (Date.today - 7).strftime('%Y-%m-%d')}))
+          end
+
+          should "be able to set end date" do
+            assert_equal ['result'], @test_model.results(@profile, 'end_date' => (Date.today - 7))
+            assert_data_params(@params.merge({'end-date' => (Date.today - 7).strftime('%Y-%m-%d')}))
+          end
 
           should "return a set of results in the defined class" do
             @test_model.stubs(:instance_klass).returns(ResultKlass)

--- a/test/unit/garb/report_response_test.rb
+++ b/test/unit/garb/report_response_test.rb
@@ -25,7 +25,7 @@ module Garb
           assert_equal [SpecialKlass, SpecialKlass, SpecialKlass], response.results.map(&:class)
         end
 
-	should "return the total number of results" do
+        should "return the total number of results" do
           response = ReportResponse.new(@file)
           assert_equal 6, response.total_results
         end

--- a/test/unit/garb/report_response_test.rb
+++ b/test/unit/garb/report_response_test.rb
@@ -24,6 +24,11 @@ module Garb
           response = ReportResponse.new(@file, SpecialKlass)
           assert_equal [SpecialKlass, SpecialKlass, SpecialKlass], response.results.map(&:class)
         end
+
+	should "return the total number of results" do
+          response = ReportResponse.new(@file)
+          assert_equal 6, response.total_results
+        end
       end
 
       should "return an empty array if there are no results" do


### PR DESCRIPTION
include ability to set start_date and end_date as specified in documentation

openSearch:totalResults is returned by Google to be used for paging.  Currently this field is not surfaced by the garb library and so paging is not usable.
