### PR TITLE
fix for phone gem conflict

### DIFF
--- a/lib/garb.rb
+++ b/lib/garb.rb
@@ -40,7 +40,7 @@ require 'garb/management/web_property'
 require 'garb/management/profile'
 require 'garb/management/goal'
 
-require 'support'
+require File.dirname(__FILE__) + '/support'
 
 module Garb
   GA = "http://schemas.google.com/analytics/2008"


### PR DESCRIPTION
I modified garb.rb to use the full path to support.rb so as not to include a support.rb elsewhere in the load path (such as in the phone gem)
