### PR TITLE
Disable read_timeout for garb http requests.

### DIFF
--- a/lib/garb/request/data.rb
+++ b/lib/garb/request/data.rb
@@ -33,6 +33,7 @@ module Garb
         http = Net::HTTP.new(uri.host, uri.port, Garb.proxy_address, Garb.proxy_port)
         http.use_ssl = true
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.read_timeout = nil
         http.get("#{uri.path}#{query_string}", {'Authorization' => "GoogleLogin auth=#{@session.auth_token}", 'GData-Version' => '2'})
       end
 


### PR DESCRIPTION
Google Analtyics reports can take a long time to return data, but will return successfully eventually in most cases. The default read_timeout in Net::HTTP is 60 seconds, which is long enough for most cases, but some users (myself included) run reports that regularly take over 60 seconds to complete.

I don't get the impression anyone's thought about the timeout too hard, so I don't think replacing "use ruby's default" with "don't time out" is a big deal, and it solves the problem up to the limits of peoples' firewalls.
