### PR TITLE
Prefix ga with - when present

### DIFF
--- a/lib/garb.rb
+++ b/lib/garb.rb
@@ -61,7 +61,7 @@ module Garb
   def to_google_analytics(thing)
     return thing.to_google_analytics if thing.respond_to?(:to_google_analytics)
 
-    "ga:#{thing.to_s.camelize(:lower)}"
+    "#{$1}ga:#{$2}" if "#{thing.to_s.camelize(:lower)}" =~ /^(-)?(.*)$/
   end
   alias :to_ga :to_google_analytics
 

--- a/test/unit/garb_test.rb
+++ b/test/unit/garb_test.rb
@@ -6,6 +6,10 @@ class GarbTest < MiniTest::Unit::TestCase
       assert_equal '-ga:bob', Garb.to_google_analytics(stub(:to_google_analytics => '-ga:bob'))
       assert_equal 'ga:bob', Garb.to_google_analytics('bob')
     end
+    
+    should 'parse out - and put it before ga:' do      
+      assert_equal '-ga:pageviews', Garb.to_google_analytics('-pageviews')      
+    end
 
     should 'remove ga: prefix' do
       assert_equal 'bob', Garb.from_google_analytics('ga:bob')


### PR DESCRIPTION
Prefixes the ga: with - with present first in the string, this need for sorting see

http://code.google.com/apis/analytics/docs/gdata/gdataReferenceDataFeed.html#sort
