### PR TITLE
Support for OAuth2::Response

### DIFF
--- a/lib/garb.rb
+++ b/lib/garb.rb
@@ -68,7 +68,7 @@ module Garb
   alias :from_ga :from_google_analytics
 
   def parse_properties(entry)
-    Hash[entry['dxp$property'].map {|p| [Garb.from_ga(p['name']),p['value']]}]
+    Hash[entry['property'].map {|p| [Garb.from_ga(p['name']),p['value']]}]
   end
 
   def parse_link(entry, rel)

--- a/lib/garb/management/feed.rb
+++ b/lib/garb/management/feed.rb
@@ -1,6 +1,8 @@
 module Garb
   module Management
     class Feed
+      require 'xmlsimple'
+      
       BASE_URL = "https://www.google.com/analytics/feeds/datasources/ga"
 
       attr_reader :request
@@ -10,7 +12,8 @@ module Garb
       end
 
       def parsed_response
-        @parsed_response ||= JSON.parse(response.body)
+        # @parsed_response ||= JSON.parse(response.body)
+        @parsed_response ||= {'feed' => XmlSimple.xml_in(response.body)}
       end
 
       def entries

--- a/lib/garb/report_response.rb
+++ b/lib/garb/report_response.rb
@@ -1,6 +1,8 @@
 module Garb  
   class ReportResponse
-    KEYS = ['dxp$metric', 'dxp$dimension']
+    require 'xmlsimple'
+
+    KEYS = ['metric', 'dimension']
 
     def initialize(response_body, instance_klass = OpenStruct)
       @data = response_body
@@ -30,7 +32,7 @@ module Garb
     end
 
     def entries
-      feed? ? [parsed_data['feed']['entry']].flatten.compact : []
+      feed? ? [parsed_data['feed']['aggregates']].flatten.compact : []
     end
 
     def parse_total_results
@@ -42,7 +44,8 @@ module Garb
     end
 
     def parsed_data
-      @parsed_data ||= JSON.parse(@data)
+      # @parsed_data ||= JSON.parse(@data)
+      @parsed_data ||= {'feed' => XmlSimple.xml_in(@data)}
     end
 
     def feed?

--- a/lib/garb/request/data.rb
+++ b/lib/garb/request/data.rb
@@ -36,7 +36,7 @@ module Garb
           oauth_user_request
         end
 
-        raise ClientError, response.body.inspect unless response.kind_of?(Net::HTTPSuccess)
+        raise ClientError, response.body.inspect unless response.kind_of?(Net::HTTPSuccess) || (response.respond_to?(:status) && response.status == 200)
         response
       end
 

--- a/lib/garb/request/data.rb
+++ b/lib/garb/request/data.rb
@@ -16,13 +16,13 @@ module Garb
       end
 
       def query_string
-        parameters.merge!("alt" => format)
+        # parameters.merge!("alt" => format)
         parameter_list = @parameters.map {|k,v| "#{k}=#{v}" }
         parameter_list.empty? ? '' : "?#{parameter_list.join('&')}"
       end
 
       def format
-        @format ||= "json" # TODO Support other formats?
+        # @format ||= "json" # TODO Support other formats?
       end
 
       def uri


### PR DESCRIPTION
Google API now supports OAuth2.  The OAuth2 gem uses Faraday wrapped by its own OAuth2::Response class.  This class behaves differently than Net::HTTP that the OAuth gem depends on.  The key difference is that OAuth2::Response exposes a method OAuth2::Response#status that returns the status code for the request.

Modified Garb::Request::Data##send_request to check for Net::HTTPSuccess or status = 200 on the response.  If neither are present, raise ClientError and return the body of the response.
