### PR TITLE
Don't escape backslash in URL parameters

### DIFF
--- a/lib/garb/filter_parameters.rb
+++ b/lib/garb/filter_parameters.rb
@@ -37,7 +37,7 @@ module Garb
       hsh.map do |k,v|
         next unless k.is_a?(SymbolOperatorMethods)
 
-        escaped_v = v.to_s.gsub(/([,;\\])/) {|c| '\\'+c}
+        escaped_v = v.to_s.gsub(/([,;])/) {|c| '\\'+c}
         "#{URI.encode(k.to_google_analytics, /[=<>]/)}#{CGI::escape(escaped_v)}"
       end.join('%3B') # Hash AND (no duplicate keys), escape char for ';' fixes oauth
     end

--- a/test/unit/garb/filter_parameters_test.rb
+++ b/test/unit/garb/filter_parameters_test.rb
@@ -35,10 +35,10 @@ module Garb
           assert_equal params, filters.to_params
         end
 
-        should "escape comma, semicolon, and backslash in values" do
+        should "escape comma, semicolon in values" do
           filters = FilterParameters.new({:url.eql => 'this;that,thing\other'})
 
-          params = {'filters' => 'ga:url%3D%3Dthis%5C%3Bthat%5C%2Cthing%5C%5Cother'}
+          params = {'filters' => 'ga:url%3D%3Dthis%5C%3Bthat%5C%2Cthing%5Cother'}
           assert_equal params, filters.to_params
         end
 


### PR DESCRIPTION
I don't know why this was done original, but according to #74 this behavior should be remove.
